### PR TITLE
use correct underlying type for `ProposalStartingTime`

### DIFF
--- a/src/Agora/ProposalTime.purs
+++ b/src/Agora/ProposalTime.purs
@@ -18,11 +18,10 @@ import Ctl.Internal.Plutus.Types.DataSchema
   )
 import Ctl.Internal.TypeLevel.Nat (Z)
 import Ctl.Internal.Types.Interval (POSIXTime)
-import Data.BigInt (BigInt)
 import Data.Generic.Rep (class Generic)
 import Data.Newtype (class Newtype)
 
-newtype ProposalStartingTime = ProposalStartingTime BigInt
+newtype ProposalStartingTime = ProposalStartingTime POSIXTime
 
 derive instance Newtype ProposalStartingTime _
 


### PR DESCRIPTION
The underlying type of `ProposalStartingTime` should be `POSIXTime`. In the on-chain code, it was defined as:
```haskell
newtype ProposalStartingTime = ProposalStartingTime
  { getProposalStartingTime :: POSIXTime
  }
```