### PR TITLE
add `DecodeAeson`, `EncodeAeson` instances for `MultiSig`, `MultiSigDatum`

### DIFF
--- a/src/Agora/MultiSig.purs
+++ b/src/Agora/MultiSig.purs
@@ -3,7 +3,7 @@ module Agora.MultiSig where
 
 import Prelude
 
-import Aeson (class DecodeAeson, decodeAeson)
+import Aeson (class DecodeAeson, class EncodeAeson, decodeAeson, encodeAeson)
 import Contract.PlutusData (class FromData, class ToData, genericFromData, genericToData)
 import Contract.Prelude (wrap)
 import Ctl.Internal.Plutus.Types.DataSchema (class HasPlutusSchema, type (:+), type (:=), type (@@), I, PNil)
@@ -41,6 +41,9 @@ instance FromData MultiSig where
 
 instance DecodeAeson MultiSig where
   decodeAeson x = wrap <$> decodeAeson x
+
+instance EncodeAeson MultiSig where
+   encodeAeson (MultiSig x) = encodeAeson x
 
 derive instance Generic MultiSig _
 

--- a/src/Agora/MultiSig.purs
+++ b/src/Agora/MultiSig.purs
@@ -3,27 +3,17 @@ module Agora.MultiSig where
 
 import Prelude
 
+import Aeson (class DecodeAeson, decodeAeson)
+import Contract.PlutusData (class FromData, class ToData, genericFromData, genericToData)
+import Contract.Prelude (wrap)
+import Ctl.Internal.Plutus.Types.DataSchema (class HasPlutusSchema, type (:+), type (:=), type (@@), I, PNil)
+import Ctl.Internal.TypeLevel.Nat (Z)
 import Ctl.Internal.Types.PubKeyHash (PubKeyHash)
 import Data.BigInt (BigInt)
 import Data.Generic.Rep (class Generic)
 import Data.Lens (Iso')
-import Ctl.Internal.TypeLevel.Nat (Z)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Newtype (class Newtype)
-import Contract.PlutusData
-  ( class FromData
-  , class ToData
-  , genericFromData
-  , genericToData
-  )
-import Ctl.Internal.Plutus.Types.DataSchema
-  ( class HasPlutusSchema
-  , type (:+)
-  , type (:=)
-  , type (@@)
-  , I
-  , PNil
-  )
 
 newtype MultiSig = MultiSig
   { keys :: Array PubKeyHash
@@ -48,6 +38,9 @@ instance ToData MultiSig where
 
 instance FromData MultiSig where
   fromData = genericFromData
+
+instance DecodeAeson MultiSig where
+  decodeAeson x = wrap <$> decodeAeson x
 
 derive instance Generic MultiSig _
 

--- a/src/Agora/Pro/MultiSig.purs
+++ b/src/Agora/Pro/MultiSig.purs
@@ -5,8 +5,10 @@ module Agora.Pro.MultiSig
 
 import Prelude
 
+import Aeson (class DecodeAeson, decodeAeson)
 import Agora.MultiSig (MultiSig)
 import Contract.PlutusData (class FromData, class ToData, PlutusData(..))
+import Contract.Prelude (wrap)
 import Contract.Value (CurrencySymbol)
 import Ctl.Internal.Plutus.Types.DataSchema (class HasPlutusSchema, type (:+), type (:=), type (@@), I, PNil)
 import Ctl.Internal.TypeLevel.Nat (Z)
@@ -50,6 +52,9 @@ instance ToData MultiSigDatum where
 
 instance FromData MultiSigDatum where
   fromData = productFromData
+
+instance DecodeAeson MultiSigDatum where
+  decodeAeson x = wrap <$> decodeAeson x
 
 derive instance Generic MultiSigDatum _
 

--- a/src/Agora/Pro/MultiSig.purs
+++ b/src/Agora/Pro/MultiSig.purs
@@ -5,7 +5,7 @@ module Agora.Pro.MultiSig
 
 import Prelude
 
-import Aeson (class DecodeAeson, decodeAeson)
+import Aeson (class DecodeAeson, class EncodeAeson, decodeAeson, encodeAeson)
 import Agora.MultiSig (MultiSig)
 import Contract.PlutusData (class FromData, class ToData, PlutusData(..))
 import Contract.Prelude (wrap)
@@ -55,6 +55,9 @@ instance FromData MultiSigDatum where
 
 instance DecodeAeson MultiSigDatum where
   decodeAeson x = wrap <$> decodeAeson x
+
+instance EncodeAeson MultiSigDatum where
+   encodeAeson (MultiSigDatum x) = encodeAeson x
 
 derive instance Generic MultiSigDatum _
 


### PR DESCRIPTION
### Summary
Add `DecodeAeson` and `EncodeAeson` instances for `MultiSig` and `MultiSigDatum` to allow for parsing from and to `JSON` files.
### Tasks
- [x] Add `DecodeAeson` instance and implement `decodeAeson` for `MultiSig`.
- [x] Add `DecodeAeson` instance and implement `decodeAeson` for `MultiSigDatum`.
- [x] Add `EncodeAeson` instance and implement `encodeAeson` for `MultiSig`.
- [x] Add `EncodeAeson` instance and implement `encodeAeson` for `MultiSigDatum`.